### PR TITLE
lib: sms: Add new SMS module

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -48,13 +48,14 @@ Kconfig*                                  @SebastianBoe
 /include/event_manager.rst                @b-gent
 /include/profiler.rst                     @b-gent
 /lib/bin/                                 @rlubos @lemrey
-/lib/at_cmd_parser/                       @rlubos
+/lib/at_cmd_parser/                       @rlubos @metc
 /lib/at_host/                             @rlubos
 /lib/at_notif/                            @pkchan
 /lib/bsdlib/                              @rlubos
 /lib/modem_info/                          @rlubos
 /lib/pdn_management/                      @rlubos
 /lib/multithreading_lock/                 @joerchan @rugeGerritsen
+/lib/sms/                                 @metc
 /samples/sensor/bh1749/                   @wlgrd
 /samples/bluetooth/                       @joerchan @lemrey @carlescufi
 /samples/bluetooth/**/*.rst               @b-gent

--- a/include/sms.h
+++ b/include/sms.h
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
+#ifndef SMS_H_
+#define SMS_H_
+
+/**
+ * @file sms.h
+ *
+ * @defgroup sms SMS subscriber manager
+ *
+ * @{
+ *
+ * @brief Public APIs of the SMS subscriber manager module.
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <zephyr/types.h>
+#include <sys/types.h>
+
+/* Forward declaration. */
+struct sms_data;
+
+/**
+ * @brief SMS listener callback function.
+ * 
+ * @param data    Read-only pointer to the SMS data. Cannot be null.
+ * @param context Pointer to the user context, if any. Same context used
+ *                in the register function.
+ */
+typedef void (*sms_callback_t)(const struct sms_data *data, void *context);
+
+/**
+ * @brief Initialize the SMS subscriber module.
+ *
+ * @return Zero on success, or a negative error code. The -EBUSY error
+ *         indicates that one SMS client has already been registered.
+ */
+int sms_init(void);
+
+/**
+ * @brief Register a new listener.
+ *
+ * A listener is identified by a unique handle value. This handle should be used
+ * to unregister the listener. A listener can be registered multiple times with
+ * the same or a different context.
+ *
+ * @param listener Callback function. Cannot be null.
+ * @param context User context. Can be null if not used.
+ * @return A unique handle identifying the listener, 
+ *         or a negative value if an error occurred.
+ * @retval -EINVAL Invalid parameters.
+ * @retval -ENOMEM No space to register new listeners.
+ */
+int sms_register_listener(sms_callback_t listener, void *context);
+
+/**
+ * @brief Unregister a listener.
+ *
+ * @param handle Handle identifying the listener to unregister.
+ */
+void sms_unregister_listener(int handle);
+
+/**
+ * @brief Uninitialize the SMS subscriber module.
+ */
+void sms_uninit(void);
+
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SMS_H_ */

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -6,11 +6,12 @@
 
 add_subdirectory(bin)
 
+add_subdirectory_ifdef(CONFIG_AT_CMD_PARSER at_cmd_parser)
+add_subdirectory_ifdef(CONFIG_AT_HOST_LIBRARY at_host)
+add_subdirectory_ifdef(CONFIG_AT_NOTIF at_notif)
 add_subdirectory_ifdef(CONFIG_BSD_LIBRARY bsdlib)
 add_subdirectory_ifdef(CONFIG_DK_LIBRARY dk_buttons_and_leds)
-add_subdirectory_ifdef(CONFIG_AT_NOTIF at_notif)
-add_subdirectory_ifdef(CONFIG_AT_HOST_LIBRARY at_host)
-add_subdirectory_ifdef(CONFIG_AT_CMD_PARSER at_cmd_parser)
 add_subdirectory_ifdef(CONFIG_MODEM_INFO modem_info)
-add_subdirectory_ifdef(CONFIG_PDN_MANAGEMENT pdn_management)
 add_subdirectory_ifdef(CONFIG_MULTITHREADING_LOCK multithreading_lock)
+add_subdirectory_ifdef(CONFIG_PDN_MANAGEMENT pdn_management)
+add_subdirectory_ifdef(CONFIG_SMS sms)

--- a/lib/Kconfig
+++ b/lib/Kconfig
@@ -6,22 +6,24 @@
 
 menu "Libraries"
 
+rsource "at_cmd_parser/Kconfig"
+
+rsource "at_host/Kconfig"
+
+rsource "at_notif/Kconfig"
+
 rsource "bin/Kconfig"
 
 rsource "bsdlib/Kconfig"
 
-rsource "at_notif/Kconfig"
-
-rsource "at_host/Kconfig"
-
 rsource "dk_buttons_and_leds/Kconfig"
-
-rsource "at_cmd_parser/Kconfig"
 
 rsource "modem_info/Kconfig"
 
+rsource "multithreading_lock/Kconfig"
+
 rsource "pdn_management/Kconfig"
 
-rsource "multithreading_lock/Kconfig"
+rsource "sms/Kconfig"
 
 endmenu

--- a/lib/sms/CMakeLists.txt
+++ b/lib/sms/CMakeLists.txt
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2019 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+#
+
+zephyr_library()
+zephyr_library_sources(sms.c)

--- a/lib/sms/Kconfig
+++ b/lib/sms/Kconfig
@@ -1,0 +1,27 @@
+#
+# Copyright (c) 2019 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+#
+
+menuconfig SMS
+	bool "SMS subscriber"
+	depends on SOC_SERIES_NRF91X
+	select AT_CMD
+	select AT_CMD_PARSER
+	select AT_NOTIF
+	help
+	  A library for managing SMS subscriptions.
+
+if SMS
+
+config SMS_MAX_SUBSCRIBERS_CNT
+	int "Maximum number of subscribers"
+	default 2
+
+module=SMS
+module-dep=LOG
+module-str= SMS library
+source "${ZEPHYR_BASE}/subsys/logging/Kconfig.template.log_config"
+
+endif # SMS

--- a/lib/sms/sms.c
+++ b/lib/sms/sms.c
@@ -1,0 +1,316 @@
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
+#include <logging/log.h>
+#include <zephyr.h>
+#include <stdio.h>
+#include <sms.h>
+#include <errno.h>
+#include <at_cmd.h>
+#include <at_cmd_parser/at_cmd_parser.h>
+#include <at_cmd_parser/at_params.h>
+#include <at_notif.h>
+
+LOG_MODULE_REGISTER(sms, CONFIG_SMS_LOG_LEVEL);
+
+#define AT_SMS_RESPONSE_MAX_LEN 256 // FIXME: Update this value to a lower value
+
+#define AT_CNMI_PARAMS_COUNT 6
+#define AT_CMT_PARAMS_COUNT 4
+
+#define AT_SMS_PARAMS_COUNT_MAX MAX(AT_CNMI_PARAMS_COUNT, AT_CMT_PARAMS_COUNT)
+
+/** @brief AT command to check if a client already exist. */
+#define AT_SMS_SUBSCRIBER_READ "AT+CNMI?"
+
+/** @brief AT command to register an SMS client. */
+#define AT_SMS_SUBSCRIBER_REGISTER "AT+CNMI=3,2,0,1"
+
+/** @brief AT command to unregister an SMS client. */
+#define AT_SMS_SUBSCRIBER_UNREGISTER "AT+CNMI=0,0,0,0"
+
+/** @brief AT command to an ACK in PDU mode. */
+#define AT_SMS_PDU_ACK "AT+CNMA=1"
+
+/** @brief Start of AT notification for incoming SMS. */
+#define AT_SMS_NOTIFICATION "+CMT:"
+#define AT_SMS_NOTIFICATION_LEN (sizeof(AT_SMS_NOTIFICATION) - 1)
+
+static struct at_param_list resp_list;
+static char resp[AT_SMS_RESPONSE_MAX_LEN];
+
+/**
+ * @brief Indicates that the module has been successfully initialized
+ * and registered as an SMS client.
+ */
+static bool sms_client_registered;
+
+/** @brief SMS PDU data. */
+struct sms_data {
+	char *alpha;
+	u16_t length;
+	char *pdu;
+};
+
+/** @brief SMS event. */
+static struct sms_data cmt_rsp;
+
+struct sms_subscriber {
+	/* Listener user context. */
+	void *ctx;
+	/* Listener callback. */
+	sms_callback_t listener;
+};
+
+/** @brief List of subscribers. */
+static struct sms_subscriber subscribers[CONFIG_SMS_MAX_SUBSCRIBERS_CNT];
+
+/** @brief Check if the received AT notification is a +CMT event. */
+static bool sms_is_cmd_notification(const char *const at_notif)
+{
+	if (at_notif == NULL) {
+		return false;
+	}
+
+	if (strlen(at_notif) <= AT_SMS_NOTIFICATION_LEN) {
+		return false;
+	}
+
+	return (strncmp(at_notif, AT_SMS_NOTIFICATION,
+			AT_SMS_NOTIFICATION_LEN) == 0);
+}
+
+/** @brief Parse the +CMT unsolicited received message in PDU mode. */
+static int sms_cmt_notif_parse(const char *const buf)
+{
+	/* Parse the received message. */
+	int err = at_parser_max_params_from_str(buf, NULL, &resp_list,
+						AT_CMT_PARAMS_COUNT);
+
+	if (err != 0) {
+		LOG_ERR("Unable to parse CMT notification, err=%d", err);
+		return err;
+	}
+
+	/* Check the AT response format. */
+	if (at_params_valid_count_get(&resp_list) != AT_CMT_PARAMS_COUNT) {
+		LOG_ERR("Invalid CMT notification format");
+		return -EAGAIN;
+	}
+
+	return 0;
+}
+
+/** @brief Extract the SMS notification parameters as save the data. */
+static int sms_cmt_notif_save(void)
+{
+	size_t alpha_len, pdu_len;
+
+	/* Save alpha as a null-terminated String. */
+	(void)at_params_size_get(&resp_list, 1, &alpha_len);
+
+	cmt_rsp.alpha = k_malloc(alpha_len + 1);
+	if (cmt_rsp.alpha == NULL) {
+		return -ENOMEM;
+	}
+	(void)at_params_string_get(&resp_list, 1, cmt_rsp.alpha, &alpha_len);
+	cmt_rsp.alpha[alpha_len] = '\0';
+
+	/* Length field saved as number. */
+	(void)at_params_short_get(&resp_list, 2, &cmt_rsp.length);
+
+	/* Save PDU as a null-terminated String. */
+	(void)at_params_size_get(&resp_list, 3, &pdu_len);
+	cmt_rsp.pdu = k_malloc(pdu_len + 1);
+	if (cmt_rsp.pdu == NULL) {
+		return -ENOMEM;
+	}
+
+	(void)at_params_string_get(&resp_list, 3, cmt_rsp.pdu, &pdu_len);
+	cmt_rsp.pdu[pdu_len] = '\0';
+
+	return 0;
+}
+
+/** @brief Handler for AT responses and unsolicited events. */
+void sms_at_handler(void *context, char *at_notif)
+{
+	ARG_UNUSED(context);
+
+	/* Check if the notification is a CMT event. */
+	if (!sms_is_cmd_notification(at_notif)) {
+		return;
+	}
+
+	/* Parse and validate the CMT notification, then extract parameters. */
+	if (sms_cmt_notif_parse(at_notif) != 0) {
+		LOG_ERR("Invalid CMT notification");
+		return;
+	}
+
+	/* Extract and save the SMS notification parameters. */
+	int valid_notif = sms_cmt_notif_save();
+
+	/* Ack the SMS PDU in any case. */
+	int ret = at_cmd_write(AT_SMS_PDU_ACK, NULL, 0, NULL);
+
+	if (ret != 0) {
+		LOG_ERR("Unable to ACK the SMS PDU");
+	}
+
+	if (valid_notif != 0) {
+		LOG_ERR("Invalid SMS notification format");
+		return;
+	}
+
+	/* Notify all subscribers. */
+	LOG_DBG("Valid SMS notification decoded");
+	for (size_t i = 0; i < ARRAY_SIZE(subscribers); i++) {
+		if (subscribers[i].listener != NULL) {
+			subscribers[i].listener(&cmt_rsp, subscribers[i].ctx);
+		}
+	}
+
+	/* Free the data of the event. */
+	if (cmt_rsp.alpha != NULL) {
+		k_free(cmt_rsp.alpha);
+	}
+
+	if (cmt_rsp.pdu != NULL) {
+		k_free(cmt_rsp.pdu);
+	}
+}
+
+int sms_init(void)
+{
+	int ret = at_params_list_init(&resp_list, AT_SMS_PARAMS_COUNT_MAX);
+
+	if (ret) {
+		LOG_ERR("AT params error, err: %d", ret);
+		return ret;
+	}
+
+	/* Check if one SMS client has already been registered. */
+	ret = at_cmd_write(AT_SMS_SUBSCRIBER_READ, resp, sizeof(resp), NULL);
+	if (ret) {
+		LOG_ERR("Unable to check if an SMS client exists, err: %d",
+			ret);
+		return ret;
+	}
+
+	ret = at_parser_max_params_from_str(resp, NULL, &resp_list,
+					    AT_CNMI_PARAMS_COUNT);
+	if (ret) {
+		LOG_INF("%s", log_strdup(resp));
+		LOG_ERR("Invalid AT response, err: %d", ret);
+		return ret;
+	}
+
+	int cnmi = 0;
+
+	for (int i = 1; i < AT_CNMI_PARAMS_COUNT - 1; i++) {
+		int value;
+
+		ret = at_params_int_get(&resp_list, i, &value);
+		if (ret) {
+			LOG_ERR("Invalid AT response parameters, err: %d", ret);
+			return ret;
+		}
+		cnmi += value;
+	}
+
+	/* No client are registered when the first 4 parameters are 0. */
+	if (cnmi != 0) {
+		LOG_ERR("Only one SMS client can be registered");
+		return -EBUSY;
+	}
+
+	/* Register for AT commands notifications before creating the client. */
+	ret = at_notif_register_handler(NULL, sms_at_handler);
+	if (ret) {
+		LOG_ERR("Cannot register AT notification handler, err: %d",
+			ret);
+		return ret;
+	}
+
+	/* Register this module as an SMS client. */
+	ret = at_cmd_write(AT_SMS_SUBSCRIBER_REGISTER, NULL, 0, NULL);
+	if (ret) {
+		(void)at_notif_deregister_handler(NULL, sms_at_handler);
+		LOG_ERR("Unable to register a new SMS client, err: %d", ret);
+		return ret;
+	}
+
+	/* Clear all observers. */
+	for (size_t i = 0; i < ARRAY_SIZE(subscribers); i++) {
+		const struct sms_subscriber *s = subscribers + i;
+
+		s->ctx = NULL;
+		s->listener = NULL;
+	}
+
+	sms_client_registered = true;
+	LOG_INF("SMS client successfully registered");
+	return 0;
+}
+
+int sms_register_listener(sms_callback_t listener, void *context)
+{
+	if (listener == NULL) {
+		return -EINVAL; /* Invalid parameter. */
+	}
+
+	/* Search for a free slot to register a new listener. */
+	for (size_t i = 0; i < ARRAY_SIZE(subscribers); i++) {
+		if (subscribers[i].ctx == NULL &&
+		    subscribers[i].listener == NULL) {
+			subscribers[i].ctx = context;
+			subscribers[i].listener = listener;
+
+			/* The array index is used as handle.
+			 * A negative value indicates an error. */
+			return i;
+		}
+	}
+
+	/* Too many subscribers. */
+	return -ENOMEM;
+}
+
+void sms_unregister_listener(int handle)
+{
+	/* Unregister the listener. */
+	if (handle < 0 || handle >= ARRAY_SIZE(subscribers)) {
+		/* Invalid handle. Unknown listener. */
+		return;
+	}
+
+	subscribers[handle].ctx = NULL;
+	subscribers[handle].listener = NULL;
+}
+
+void sms_uninit(void)
+{
+	/* Unregister the SMS client if this module was registered as client. */
+	if (sms_client_registered) {
+		int ret = at_cmd_write(AT_SMS_SUBSCRIBER_UNREGISTER, resp,
+				       sizeof(resp), NULL);
+		if (ret) {
+			LOG_ERR("Unable to unregister the SMS client, err: %d",
+				ret);
+			return;
+		}
+		LOG_INF("SMS client unregistered");
+	}
+
+	/* Cleanup resources. */
+	at_params_list_free(&resp_list);
+
+	/* Unregister from AT commands notifications. */
+	(void)at_notif_deregister_handler(NULL, sms_at_handler);
+
+	sms_client_registered = false;
+}


### PR DESCRIPTION
The SMS module allows to have multiple SMS clients in the system. It
acts as a central SMS client and dispatch SMS data to multiple
listeners. This module acknowledge SMS on the behalf on each listeners.

Multiple listener can register and get notified when a SMS is received.
SMS are read using AT commands, using the shared AT socket.

Signed-off-by: Christopher Métrailler <christopher.metrailler@nordicsemi.no>